### PR TITLE
handle state change when no checkouts elegantly

### DIFF
--- a/scenes/customer/Customer.gd
+++ b/scenes/customer/Customer.gd
@@ -10,6 +10,8 @@ extends CharacterBody2D
 var basket: Dictionary = {}
 var products_wanted: Array[String] = []
 
+var notification_tween: Tween = null # tween used to fade out floating notifcation
+
 # min and max products amounts are the range of numbers of product a customer
 # will attempt to purchase
 @export var min_products := 1
@@ -52,13 +54,21 @@ func get_wanted_products() -> Array[String]:
 
 # add_floating_notification displays the provided message above the customer sprite
 # for the given duration. The label used is not despawned, but the text is cleared.
-func add_floating_notification(message: String, duration: float = 5.0):
+func add_floating_notification(message: String, duration: float = 3.0):
+	# Cancel any existing tween
+	if notification_tween and notification_tween.is_valid():
+		notification_tween.kill()
+
+	# Reset opacity and set new message
+	notification_label.modulate.a = 1.0
 	notification_label.text = message
-	
-	var tween = notification_label.create_tween()
-	tween.tween_interval(duration)
-	tween.tween_property(notification_label, "modulate:a", 0.0, 0.5)
-	tween.finished.connect(func():
+
+	# Create and store new tween
+	notification_tween = notification_label.create_tween()
+	notification_tween.tween_interval(duration)
+	notification_tween.tween_property(notification_label, "modulate:a", 0.0, 0.5)
+
+	notification_tween.finished.connect(func():
 		if is_instance_valid(notification_label):
 			notification_label.text = ""
 	)

--- a/scenes/customer/Customer.tscn
+++ b/scenes/customer/Customer.tscn
@@ -78,9 +78,10 @@ wandering = NodePath("../Wandering")
 finding_product = NodePath("../FindingProduct")
 metadata/_custom_type_script = "uid://b410q60jy23fl"
 
-[node name="WalkingToCheckout" type="Node" parent="StateMachine" node_paths=PackedStringArray("checking_out")]
+[node name="WalkingToCheckout" type="Node" parent="StateMachine" node_paths=PackedStringArray("checking_out", "wandering")]
 script = ExtResource("7_ncdiv")
 checking_out = NodePath("../CheckingOut")
+wandering = NodePath("../Wandering")
 metadata/_custom_type_script = "uid://b410q60jy23fl"
 
 [node name="WalkingToShelf" type="Node" parent="StateMachine" node_paths=PackedStringArray("wandering", "interacting_with_shelf")]

--- a/scenes/customer/states/CheckingOut.gd
+++ b/scenes/customer/states/CheckingOut.gd
@@ -6,6 +6,8 @@ extends State
 func enter() -> void:
 	super()
 	
+	parent.add_floating_notification("checkout out!")
+	
 	if parent.checkout == null:
 		_should_transition = true
 		_next_state = wandering

--- a/scenes/customer/states/FindingProduct.gd
+++ b/scenes/customer/states/FindingProduct.gd
@@ -15,6 +15,8 @@ func enter() -> void:
 		else:
 			var product_id = parent.products_wanted.pop_front()
 			parent.current_product = ProductDatabase.get_product(product_id)
+			parent.add_floating_notification("getting %s" % parent.current_product.label)
+			
 			_should_transition = true
 			_next_state = walking_to_shelf
 	else:

--- a/scenes/customer/states/WalkingToCheckout.gd
+++ b/scenes/customer/states/WalkingToCheckout.gd
@@ -1,15 +1,21 @@
 extends State
 
 @export var checking_out: State
+@export var wandering: State
 
 func enter() -> void:
 	super()
 	parent.checkout = StoreManager.get_open_checkout()
-	if parent.checkout == null:
-		push_error("checkout should not be null")
-	set_target_position(parent.checkout.global_position)
+	if parent.checkout != null:
+		set_target_position(parent.checkout.global_position)
+	else:
+		_should_transition = true
+		_next_state = wandering
 
 func process_frame(_delta: float) -> State:
+	if _should_transition:
+		return _next_state
+		
 	move_towards_target()
 	await nav_agent.target_reached
 	return checking_out

--- a/scenes/customer/states/WalkingToCheckout.gd
+++ b/scenes/customer/states/WalkingToCheckout.gd
@@ -5,10 +5,14 @@ extends State
 
 func enter() -> void:
 	super()
+	
+	parent.add_floating_notification("done shopping, going to check out!")
+	
 	parent.checkout = StoreManager.get_open_checkout()
 	if parent.checkout != null:
 		set_target_position(parent.checkout.global_position)
 	else:
+		parent.add_floating_notification("no checkouts available! :(")
 		_should_transition = true
 		_next_state = wandering
 

--- a/scripts/StoreManager.gd
+++ b/scripts/StoreManager.gd
@@ -42,6 +42,8 @@ func unregister_checkout(checkout: Checkout) -> void:
 	checkouts.erase(checkout)
 
 func get_open_checkout() -> Checkout:
+	if checkouts.size() == 0:
+		return null
 	return checkouts[randi() % checkouts.size()]
 
 ## Doors


### PR DESCRIPTION
https://github.com/ericso/a-supermarket-darkly/issues/60

The game would crash if customers transitioned to the checkout state and there were no checkout nodes available. This change is so that the customers transition back to the wandering state in that case.