### PR TITLE
Bugfix/shelf checkout simultaneous

### DIFF
--- a/scenes/main/Main.tscn
+++ b/scenes/main/Main.tscn
@@ -99,6 +99,7 @@ script = ExtResource("4_sjxhf")
 script = ExtResource("6_3km4f")
 
 [node name="TabButton" type="Button" parent="UI/SideMenu"]
+layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
 text = ">"

--- a/scenes/main/StorePlacer.gd
+++ b/scenes/main/StorePlacer.gd
@@ -46,14 +46,18 @@ func _process(_delta) -> void:
 		update_shadow_color(can_place_checkout_at(snapped_pos))
 
 func on_place_shelf_pressed():
-	store_panel.set_place_shelf_mode_enabled(!is_placing_shelf)
+	if is_placing_checkout:
+		stop_placing_checkout()
+	
 	if is_placing_shelf:
 		stop_placing_shelf()
 	else:
 		start_placing_shelf()
 
 func on_place_checkout_pressed():
-	store_panel.set_place_checkout_mode_enabled(!is_placing_checkout)
+	if is_placing_shelf:
+		stop_placing_shelf()
+	
 	if is_placing_checkout:
 		stop_placing_checkout()
 	else:
@@ -95,23 +99,27 @@ func start_placing_shelf() -> void:
 	is_placing_shelf = true
 	shadow_shelf_scene = preload("res://scenes/shelf/ShadowShelf.tscn").instantiate()
 	add_child(shadow_shelf_scene)
+	store_panel.set_place_shelf_mode_enabled(true)
 
 func stop_placing_shelf() -> void:
 	is_placing_shelf = false
 	if shadow_shelf_scene:
 		shadow_shelf_scene.queue_free()
 		shadow_shelf_scene = null
+	store_panel.set_place_shelf_mode_enabled(false)
 
 func start_placing_checkout() -> void:
 	is_placing_checkout = true
 	shadow_checkout_scene = preload("res://scenes/checkout/ShadowCheckout.tscn").instantiate()
 	add_child(shadow_checkout_scene)
+	store_panel.set_place_checkout_mode_enabled(true)
 
 func stop_placing_checkout() -> void:
 	is_placing_checkout = false
 	if shadow_checkout_scene:
 		shadow_checkout_scene.queue_free()
 		shadow_checkout_scene = null
+	store_panel.set_place_checkout_mode_enabled(false)
 
 func update_shadow_color(is_valid: bool):
 	if shadow_shelf_scene:

--- a/scenes/main/StorePlacer.gd
+++ b/scenes/main/StorePlacer.gd
@@ -16,6 +16,7 @@ var is_placing_checkout: bool = false
 func _ready() -> void:
 	store_panel.connect("place_shelf_button_pressed", self.on_place_shelf_pressed)
 	store_panel.connect("place_checkout_button_pressed", self.on_place_checkout_pressed)
+	store_panel.connect("back_button_pressed", self.terminate_all_placing_modes)
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed:
@@ -62,6 +63,10 @@ func on_place_checkout_pressed():
 		stop_placing_checkout()
 	else:
 		start_placing_checkout()
+		
+func terminate_all_placing_modes() -> void:
+	stop_placing_shelf()
+	stop_placing_checkout()
 
 func can_place_shelf_at(tile_pos: Vector2i) -> bool:
 	var world_pos = store_map.map_to_local(tile_pos)

--- a/scenes/main/side_menu/StorePanel.gd
+++ b/scenes/main/side_menu/StorePanel.gd
@@ -20,6 +20,7 @@ func on_checkout_button_pressed():
 
 # TODO refactor placing shelves and checkouts into common code
 # probably do it when changing this to purchasing checkouts and shelves
+# maybe this isn't worth it as there are only two modes
 func set_place_shelf_mode_enabled(enabled: bool):
 	shelf_button.text = "Placing Shelves" if enabled else "Place Shelves"
 	shelf_button.modulate = Color(0.7, 1, 0.7) if enabled else Color(1, 1, 1)

--- a/scenes/main/side_menu/StorePanel.gd
+++ b/scenes/main/side_menu/StorePanel.gd
@@ -2,6 +2,7 @@ extends VBoxContainer
 
 signal place_shelf_button_pressed
 signal place_checkout_button_pressed
+signal back_button_pressed
 
 @onready var shelf_button := $ShelfButton
 @onready var checkout_button := $CheckoutButton
@@ -18,9 +19,11 @@ func on_shelf_button_pressed():
 func on_checkout_button_pressed():
 	emit_signal("place_checkout_button_pressed")
 
-# TODO refactor placing shelves and checkouts into common code
-# probably do it when changing this to purchasing checkouts and shelves
-# maybe this isn't worth it as there are only two modes
+func on_back_button_pressed():
+	emit_signal("back_button_pressed")
+	var side_menu = get_node(side_menu_path)
+	side_menu.go_back()
+
 func set_place_shelf_mode_enabled(enabled: bool):
 	shelf_button.text = "Placing Shelves" if enabled else "Place Shelves"
 	shelf_button.modulate = Color(0.7, 1, 0.7) if enabled else Color(1, 1, 1)
@@ -36,7 +39,3 @@ func set_place_checkout_mode_enabled(enabled: bool):
 		Input.set_default_cursor_shape(Input.CURSOR_CROSS)
 	else:
 		Input.set_default_cursor_shape(Input.CURSOR_ARROW)
-
-func on_back_button_pressed():
-	var side_menu = get_node(side_menu_path)
-	side_menu.go_back()


### PR DESCRIPTION
Issue: https://github.com/ericso/a-supermarket-darkly/issues/66

- modes are now dependent, activating placing shelf mode deactivates placing checkout mode and vice versa
- pressing the back button in the menu deactivates any active mode